### PR TITLE
Update python_version 3.13 phase 5

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13

--- a/zoom.json
+++ b/zoom.json
@@ -7,7 +7,7 @@
     "logo": "logo_zoom.svg",
     "logo_dark": "logo_zoom_dark.svg",
     "product_name": "Zoom Meetings",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Splunk",
     "license": "Copyright (c) 2021-2025 Splunk Inc.",


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 5 part 2

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase5-part2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase5-part2)