### PR TITLE
fix: remediate Zoom connector security findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -391,7 +391,6 @@ PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
 DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
 action_result.parameter.user_id | string | `zoom user id` `email` | |
-action_result.parameter.password | password | | |
 action_result.parameter.gen_password | boolean | | |
 action_result.parameter.waiting_room | string | | |
 action_result.parameter.topic | string | | |
@@ -403,16 +402,12 @@ action_result.parameter.meeting_invitees | string | | |
 action_result.data.\*.host_id | string | `zoom user id` | 22test-TeSTiNgZg8NTeST |
 action_result.summary.meeting_id | string | `zoom meeting id` | 97648930957 |
 action_result.data.\*.join_url | string | | https://zoom.us/T/99999999999 |
-action_result.data.\*.password | string | | I2q8w&DSw |
 action_result.data.\*.id | numeric | | 99999999999 |
 action_result.data.\*.type | numeric | | 2 |
 action_result.data.\*.uuid | string | | ztest22test/testWwC6VA== |
 action_result.data.\*.topic | string | | Zoom Meeting |
 action_result.data.\*.status | string | | waiting |
 action_result.data.\*.agenda | string | | This is test agenda for create meeting action. This is test agenda for create meeting action. This is test agenda for create meeting action. |
-action_result.data.\*.h323_password | string | | 800645960 |
-action_result.data.\*.pstn_password | string | | 800645960 |
-action_result.data.\*.encrypted_password | string | | uGBNumrMF6BPFw85hBNTApbDBeO7aI.1 |
 action_result.data.\*.duration | numeric | | 60 |
 action_result.data.\*.settings.audio | string | | both |
 action_result.data.\*.settings.use_pmi | boolean | | True False |
@@ -471,7 +466,6 @@ action_result.data.\*.created_at | string | | 2024-09-10T11:48:20Z |
 action_result.data.\*.host_email | string | | test@test.in |
 action_result.data.\*.start_time | string | | 2024-09-10T11:48:20Z |
 action_result.data.\*.pre_schedule | boolean | | True False |
-action_result.summary.password | string | | Not Added |
 action_result.summary.waiting_room | string | | Not Added |
 action_result.summary.auto_recording | string | | cloud |
 action_result.summary.meeting_created | boolean | | True False |
@@ -485,6 +479,7 @@ action_result.summary | string | | |
 action_result.message | string | | |
 summary.total_objects | numeric | | |
 summary.total_objects_successful | numeric | | |
+action_result.parameter.password | password | | |
 
 ## action: 'get meeting'
 
@@ -509,8 +504,6 @@ action_result.data.\*.agenda | string | | |
 action_result.data.\*.assistant_id | string | | |
 action_result.data.\*.created_at | string | | |
 action_result.data.\*.duration | numeric | | |
-action_result.data.\*.encrypted_password | string | | |
-action_result.data.\*.h323_password | string | | |
 action_result.data.\*.host_email | string | | |
 action_result.data.\*.host_id | string | | |
 action_result.data.\*.id | numeric | | |
@@ -519,10 +512,8 @@ action_result.data.\*.occurrences.\*.duration | numeric | | |
 action_result.data.\*.occurrences.\*.occurrence_id | string | | |
 action_result.data.\*.occurrences.\*.start_time | string | | |
 action_result.data.\*.occurrences.\*.status | string | | |
-action_result.data.\*.password | string | | |
 action_result.data.\*.pmi | numeric | | |
 action_result.data.\*.pre_schedule | boolean | | |
-action_result.data.\*.pstn_password | string | | |
 action_result.data.\*.recurrence.end_date_time | string | | |
 action_result.data.\*.recurrence.end_times | numeric | | |
 action_result.data.\*.recurrence.monthly_day | numeric | | |
@@ -615,15 +606,14 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 action_result.status | string | | success failed |
 action_result.parameter.gen_password | boolean | | None True False |
 action_result.parameter.meeting_id | string | `zoom meeting id` | 92512345678 |
-action_result.parameter.password | password | | testPass1 |
 action_result.parameter.waiting_room | string | | None |
 action_result.data | string | | |
 action_result.summary.meeting_updated | boolean | | True False |
-action_result.summary.password | string | | testxFghbsuHndTYGF |
 action_result.summary.waiting_room | string | | Not Updated |
 action_result.message | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.password | password | | |
 
 ## action: 'delete meeting'
 
@@ -677,7 +667,6 @@ DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
 --------- | ---- | -------- | --------------
 action_result.status | string | | success failed |
 action_result.parameter.gen_pmi_password | boolean | | None True False |
-action_result.parameter.pmi_password | password | | test@123 |
 action_result.parameter.req_password_inst | string | | None |
 action_result.parameter.req_password_pmi | string | | None |
 action_result.parameter.req_password_sched | string | | None |
@@ -685,7 +674,6 @@ action_result.parameter.user_id | string | `zoom user id` | A0BiCtoDEFGHIzYaZcLd
 action_result.parameter.user_id | string | `zoom user id` | A0BiCtoDEFGHIzYaZcLdsA |
 action_result.parameter.waiting_room | string | | None |
 action_result.data | string | | |
-action_result.summary.pmi_password | string | | Not Updated |
 action_result.summary.require_password_for_instant_meetings | string | | Not Updated |
 action_result.summary.require_password_for_personal_meeting_instance | string | | Not Updated |
 action_result.summary.require_password_for_scheduling_new_meetings | string | | Not Updated |
@@ -693,6 +681,7 @@ action_result.summary.waiting_room | string | | Not Updated |
 action_result.message | string | | |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
+action_result.parameter.pmi_password | password | | |
 
 ______________________________________________________________________
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: refresh development checks (temporary baseline note).

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Validated meeting and user identifiers before using them in Zoom API paths. (PAPP-38043)
 * Preserved password-policy settings when optional update values are omitted. (PAPP-38043)
 * Prevented meeting and PMI credentials from being persisted in action results. (PAPP-38043)
+* Excluded OAuth token responses from action debug data. (PAPP-38043)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: refresh development checks (temporary baseline note).
+* Validated meeting and user identifiers before using them in Zoom API paths. (PAPP-38043)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Validated meeting and user identifiers before using them in Zoom API paths. (PAPP-38043)
+* Preserved password-policy settings when optional update values are omitted. (PAPP-38043)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Validated meeting and user identifiers before using them in Zoom API paths. (PAPP-38043)
 * Preserved password-policy settings when optional update values are omitted. (PAPP-38043)
+* Prevented meeting and PMI credentials from being persisted in action results. (PAPP-38043)

--- a/zoom.json
+++ b/zoom.json
@@ -1205,56 +1205,52 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.parameter.password",
-                    "data_type": "password"
-                },
-                {
                     "data_path": "action_result.parameter.gen_password",
                     "data_type": "boolean",
                     "column_name": "Gen Password",
-                    "column_order": 4
+                    "column_order": 3
                 },
                 {
                     "data_path": "action_result.parameter.waiting_room",
                     "data_type": "string",
                     "column_name": "Waiting Room",
-                    "column_order": 5
+                    "column_order": 4
                 },
                 {
                     "data_path": "action_result.parameter.topic",
                     "data_type": "string",
                     "column_name": "Topic",
-                    "column_order": 6
+                    "column_order": 5
                 },
                 {
                     "data_path": "action_result.parameter.agenda",
                     "data_type": "string",
                     "column_name": "Agenda",
-                    "column_order": 7
+                    "column_order": 6
                 },
                 {
                     "data_path": "action_result.parameter.alternative_hosts",
                     "data_type": "string",
                     "column_name": "Alternative Hosts",
-                    "column_order": 8
+                    "column_order": 7
                 },
                 {
                     "data_path": "action_result.parameter.continuous_meeting_chat",
                     "data_type": "boolean",
                     "column_name": "Continuous Meeting Chat",
-                    "column_order": 9
+                    "column_order": 8
                 },
                 {
                     "data_path": "action_result.parameter.auto_recording",
                     "data_type": "string",
                     "column_name": "Auto Recording",
-                    "column_order": 10
+                    "column_order": 9
                 },
                 {
                     "data_path": "action_result.parameter.meeting_invitees",
                     "data_type": "string",
                     "column_name": "Meeting Invitees",
-                    "column_order": 11
+                    "column_order": 10
                 },
                 {
                     "data_path": "action_result.data.*.host_id",
@@ -1288,15 +1284,6 @@
                     ],
                     "column_name": "Join URL",
                     "column_order": 2
-                },
-                {
-                    "data_path": "action_result.data.*.password",
-                    "data_type": "string",
-                    "example_values": [
-                        "I2q8w&DSw"
-                    ],
-                    "column_name": "Passcode",
-                    "column_order": 3
                 },
                 {
                     "data_path": "action_result.data.*.id",
@@ -1338,27 +1325,6 @@
                     "data_type": "string",
                     "example_values": [
                         "This is test agenda for create meeting action. This is test agenda for create meeting action. This is test agenda for create meeting action."
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.h323_password",
-                    "data_type": "string",
-                    "example_values": [
-                        "800645960"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.pstn_password",
-                    "data_type": "string",
-                    "example_values": [
-                        "800645960"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.encrypted_password",
-                    "data_type": "string",
-                    "example_values": [
-                        "uGBNumrMF6BPFw85hBNTApbDBeO7aI.1"
                     ]
                 },
                 {
@@ -1801,13 +1767,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.summary.password",
-                    "data_type": "string",
-                    "example_values": [
-                        "Not Added"
-                    ]
-                },
-                {
                     "data_path": "action_result.summary.waiting_room",
                     "data_type": "string",
                     "example_values": [
@@ -1858,7 +1817,7 @@
                     "data_path": "action_result.status",
                     "data_type": "string",
                     "column_name": "Status",
-                    "column_order": 12,
+                    "column_order": 11,
                     "example_values": [
                         "success",
                         "failed"
@@ -1883,6 +1842,10 @@
                 {
                     "data_path": "summary.total_objects_successful",
                     "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.parameter.password",
+                    "data_type": "password"
                 }
             ],
             "render": {
@@ -1950,14 +1913,6 @@
                     "column_order": 3
                 },
                 {
-                    "data_path": "action_result.data.*.encrypted_password",
-                    "data_type": "string"
-                },
-                {
-                    "data_path": "action_result.data.*.h323_password",
-                    "data_type": "string"
-                },
-                {
                     "data_path": "action_result.data.*.host_email",
                     "data_type": "string"
                 },
@@ -1995,20 +1950,12 @@
                     "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.data.*.password",
-                    "data_type": "string"
-                },
-                {
                     "data_path": "action_result.data.*.pmi",
                     "data_type": "numeric"
                 },
                 {
                     "data_path": "action_result.data.*.pre_schedule",
                     "data_type": "boolean"
-                },
-                {
-                    "data_path": "action_result.data.*.pstn_password",
-                    "data_type": "string"
                 },
                 {
                     "data_path": "action_result.data.*.recurrence.end_date_time",
@@ -2377,13 +2324,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.parameter.password",
-                    "data_type": "password",
-                    "example_values": [
-                        "testPass1"
-                    ]
-                },
-                {
                     "data_path": "action_result.parameter.waiting_room",
                     "data_type": "string",
                     "example_values": [
@@ -2400,13 +2340,6 @@
                     "example_values": [
                         true,
                         false
-                    ]
-                },
-                {
-                    "data_path": "action_result.summary.password",
-                    "data_type": "string",
-                    "example_values": [
-                        "testxFghbsuHndTYGF"
                     ]
                 },
                 {
@@ -2433,6 +2366,10 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.password",
+                    "data_type": "password"
                 }
             ],
             "render": {
@@ -2615,13 +2552,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.parameter.pmi_password",
-                    "data_type": "password",
-                    "example_values": [
-                        "test@123"
-                    ]
-                },
-                {
                     "data_path": "action_result.parameter.req_password_inst",
                     "data_type": "string",
                     "example_values": [
@@ -2676,13 +2606,6 @@
                     "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.summary.pmi_password",
-                    "data_type": "string",
-                    "example_values": [
-                        "Not Updated"
-                    ]
-                },
-                {
                     "data_path": "action_result.summary.require_password_for_instant_meetings",
                     "data_type": "string",
                     "example_values": [
@@ -2727,6 +2650,10 @@
                     "example_values": [
                         1
                     ]
+                },
+                {
+                    "data_path": "action_result.parameter.pmi_password",
+                    "data_type": "password"
                 }
             ],
             "render": {

--- a/zoom_connector.py
+++ b/zoom_connector.py
@@ -55,6 +55,10 @@ class ZoomConnector(BaseConnector):
 
         return quote(value, safe="")
 
+    @staticmethod
+    def _is_setting_selected(value):
+        return value is not None and value != "None"
+
     def _get_error_message_from_exception(self, e):
         """
         Get appropriate error message from the exception.
@@ -253,28 +257,35 @@ class ZoomConnector(BaseConnector):
         req_password_inst = param.get("req_password_inst")
         req_password_pmi = param.get("req_password_pmi")
 
-        is_waiting_room_updated = waiting_room != "None"
-        is_req_password_sched_updated = req_password_sched != "None"  # pragma: allowlist secret
-        is_req_password_inst = req_password_inst != "None"  # pragma: allowlist secret
-        if not (pmi_password or is_waiting_room_updated or is_req_password_sched_updated or is_req_password_inst):
+        is_waiting_room_updated = self._is_setting_selected(waiting_room)
+        is_req_password_sched_updated = self._is_setting_selected(req_password_sched)
+        is_req_password_inst_updated = self._is_setting_selected(req_password_inst)
+        is_req_password_pmi_updated = self._is_setting_selected(req_password_pmi)
+        if not (
+            pmi_password
+            or is_waiting_room_updated
+            or is_req_password_sched_updated
+            or is_req_password_inst_updated
+            or is_req_password_pmi_updated
+        ):
             return action_result.set_status(phantom.APP_ERROR, "No settings were selected for update")
 
         data = {}
 
-        if pmi_password or req_password_sched != "None" or req_password_inst != "None" or req_password_pmi != "None":  # pragma: allowlist secret
+        if pmi_password or is_req_password_sched_updated or is_req_password_inst_updated or is_req_password_pmi_updated:
             data["schedule_meeting"] = {}
             if pmi_password:
                 data["schedule_meeting"]["pmi_password"] = pmi_password
-            if req_password_sched:
+            if is_req_password_sched_updated:
                 is_req_pass_true = req_password_sched == "True"  # pragma: allowlist secret
                 data["schedule_meeting"]["require_password_for_scheduling_new_meetings"] = is_req_pass_true
-            if req_password_inst:
+            if is_req_password_inst_updated:
                 is_req_pass_inst_true = req_password_inst == "True"  # pragma: allowlist secret
                 data["schedule_meeting"]["require_password_for_instant_meetings"] = is_req_pass_inst_true
-            if req_password_pmi:
+            if is_req_password_pmi_updated:
                 req_pass_pmi = "all" if req_password_pmi == "True" else "none"  # pragma: allowlist secret
                 data["schedule_meeting"]["require_password_for_pmi_meetings"] = req_pass_pmi
-        if waiting_room != "None":
+        if is_waiting_room_updated:
             data["in_meeting"] = {"waiting_room": waiting_room == "True"}
 
         ret_val, _ = self._make_rest_call(f"/users/{user_id_path}/settings", action_result, json=data, headers=None, method="patch")
@@ -285,16 +296,10 @@ class ZoomConnector(BaseConnector):
         action_result.update_summary(
             {
                 "pmi_password": ("Not Updated" if not (pmi_password) else pmi_password),
-                "waiting_room": ("Not Updated" if waiting_room == "None" else waiting_room),
-                "require_password_for_instant_meetings": (
-                    "Not Updated" if req_password_inst == "None" else req_password_inst  # pragma: allowlist secret
-                ),
-                "require_password_for_scheduling_new_meetings": (
-                    "Not Updated" if req_password_sched == "None" else req_password_sched  # pragma: allowlist secret
-                ),
-                "require_password_for_personal_meeting_instance": (
-                    "Not Updated" if req_password_pmi == "None" else req_password_pmi  # pragma: allowlist secret
-                ),
+                "waiting_room": ("Not Updated" if not is_waiting_room_updated else waiting_room),
+                "require_password_for_instant_meetings": ("Not Updated" if not is_req_password_inst_updated else req_password_inst),
+                "require_password_for_scheduling_new_meetings": ("Not Updated" if not is_req_password_sched_updated else req_password_sched),
+                "require_password_for_personal_meeting_instance": ("Not Updated" if not is_req_password_pmi_updated else req_password_pmi),
             }
         )
 

--- a/zoom_connector.py
+++ b/zoom_connector.py
@@ -162,8 +162,9 @@ class ZoomConnector(BaseConnector):
         # store the r_text in debug data, it will get dumped in the logs if the action fails
         if hasattr(action_result, "add_debug_data"):
             action_result.add_debug_data({"r_status_code": r.status_code})
-            action_result.add_debug_data({"r_text": r.text})
-            action_result.add_debug_data({"r_headers": r.headers})
+            if str(getattr(r, "url", "")).split("?", 1)[0].rstrip("/") != GET_TOKEN_URL:
+                action_result.add_debug_data({"r_text": r.text})
+                action_result.add_debug_data({"r_headers": r.headers})
 
         # Process each 'Content-Type' of response separately
 

--- a/zoom_connector.py
+++ b/zoom_connector.py
@@ -17,7 +17,7 @@
 # Phantom App imports
 import json
 from http import HTTPStatus
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 import encryption_helper
 import phantom.app as phantom
@@ -45,6 +45,15 @@ class ZoomConnector(BaseConnector):
         self._token = None
         self._base_url = None
         self._client_id = self._client_secret = self._account_id = None
+
+    @staticmethod
+    def _encode_path_segment(value, parameter_name):
+        value = str(value)
+
+        if not value or ".." in value or any(character in value for character in ("/", "\\", "?", "#")):
+            raise ValueError(f"{parameter_name} contains invalid path characters")
+
+        return quote(value, safe="")
 
     def _get_error_message_from_exception(self, e):
         """
@@ -214,8 +223,12 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         user_id = param["user_id"]
+        try:
+            user_id_path = self._encode_path_segment(user_id, "user_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
-        ret_val, response = self._make_rest_call(f"/users/{user_id}/settings", action_result, params=None, headers=None)
+        ret_val, response = self._make_rest_call(f"/users/{user_id_path}/settings", action_result, params=None, headers=None)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -229,6 +242,10 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         user_id = param["user_id"]
+        try:
+            user_id_path = self._encode_path_segment(user_id, "user_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
         pmi_password = self._get_password(param.get("pmi_password"), param.get("gen_pmi_password"))
         waiting_room = param.get("waiting_room")
@@ -260,7 +277,7 @@ class ZoomConnector(BaseConnector):
         if waiting_room != "None":
             data["in_meeting"] = {"waiting_room": waiting_room == "True"}
 
-        ret_val, _ = self._make_rest_call(f"/users/{user_id}/settings", action_result, json=data, headers=None, method="patch")
+        ret_val, _ = self._make_rest_call(f"/users/{user_id_path}/settings", action_result, json=data, headers=None, method="patch")
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -289,8 +306,12 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         meeting_id = param["meeting_id"]
+        try:
+            meeting_id_path = self._encode_path_segment(meeting_id, "meeting_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
-        ret_val, _ = self._make_rest_call(f"/meetings/{meeting_id}", action_result, headers=None, method="delete")
+        ret_val, _ = self._make_rest_call(f"/meetings/{meeting_id_path}", action_result, headers=None, method="delete")
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -317,6 +338,10 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         user_id = param["user_id"]
+        try:
+            user_id_path = self._encode_path_segment(user_id, "user_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
         password = self._get_password(param.get("password"), param.get("gen_password"))
         waiting_room = param.get("waiting_room")
         topic = param.get("topic")
@@ -360,7 +385,7 @@ class ZoomConnector(BaseConnector):
             if attendees:
                 data["settings"]["meeting_invitees"] = [{"email": attendee} for attendee in attendees]
 
-        ret_val, res = self._make_rest_call(f"/users/{user_id}/meetings", action_result, json=data, headers=None, method="post")
+        ret_val, res = self._make_rest_call(f"/users/{user_id_path}/meetings", action_result, json=data, headers=None, method="post")
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -389,6 +414,10 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         meeting_id = param["meeting_id"]
+        try:
+            meeting_id_path = self._encode_path_segment(meeting_id, "meeting_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
         password = self._get_password(param.get("password"), param.get("gen_password"))
         waiting_room = param.get("waiting_room")
 
@@ -402,7 +431,7 @@ class ZoomConnector(BaseConnector):
         if waiting_room != "None":
             data["settings"] = {"waiting_room": (waiting_room == "True")}
 
-        ret_val, _ = self._make_rest_call(f"/meetings/{meeting_id}", action_result, json=data, headers=None, method="patch")
+        ret_val, _ = self._make_rest_call(f"/meetings/{meeting_id_path}", action_result, json=data, headers=None, method="patch")
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -419,8 +448,12 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         meeting_id = param["meeting_id"]
+        try:
+            meeting_id_path = self._encode_path_segment(meeting_id, "meeting_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
-        ret_val, response = self._make_rest_call(f"/meetings/{meeting_id}/invitation", action_result, params=None, headers=None)
+        ret_val, response = self._make_rest_call(f"/meetings/{meeting_id_path}/invitation", action_result, params=None, headers=None)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -456,8 +489,12 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         user_id = param["user_id"]
+        try:
+            user_id_path = self._encode_path_segment(user_id, "user_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
-        ret_val, response = self._make_rest_call(f"/users/{user_id}", action_result, params=None, headers=None)
+        ret_val, response = self._make_rest_call(f"/users/{user_id_path}", action_result, params=None, headers=None)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()
@@ -471,8 +508,12 @@ class ZoomConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         meeting_id = param["meeting_id"]
+        try:
+            meeting_id_path = self._encode_path_segment(meeting_id, "meeting_id")
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
-        ret_val, response = self._make_rest_call(f"/meetings/{meeting_id}", action_result, params=None, headers=None)
+        ret_val, response = self._make_rest_call(f"/meetings/{meeting_id_path}", action_result, params=None, headers=None)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()

--- a/zoom_connector.py
+++ b/zoom_connector.py
@@ -17,7 +17,7 @@
 # Phantom App imports
 import json
 from http import HTTPStatus
-from urllib.parse import quote, unquote
+from urllib.parse import parse_qsl, quote, unquote, urlencode, urlsplit, urlunsplit
 
 import encryption_helper
 import phantom.app as phantom
@@ -58,6 +58,30 @@ class ZoomConnector(BaseConnector):
     @staticmethod
     def _is_setting_selected(value):
         return value is not None and value != "None"
+
+    @staticmethod
+    def _without_secret_parameters(param, *secret_names):
+        safe_param = dict(param)
+        for secret_name in secret_names:
+            safe_param.pop(secret_name, None)
+        return safe_param
+
+    @staticmethod
+    def _without_meeting_credentials(response):
+        safe_response = dict(response)
+        for field_name in ("password", "h323_password", "pstn_password", "encrypted_password"):
+            safe_response.pop(field_name, None)
+
+        for field_name in ("join_url", "start_url"):
+            value = safe_response.get(field_name)
+            if not value:
+                continue
+
+            parsed = urlsplit(value)
+            query = urlencode([(key, query_value) for key, query_value in parse_qsl(parsed.query) if key.lower() != "pwd"])
+            safe_response[field_name] = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+
+        return safe_response
 
     def _get_error_message_from_exception(self, e):
         """
@@ -243,7 +267,7 @@ class ZoomConnector(BaseConnector):
     def _handle_update_user_settings(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._without_secret_parameters(param, "pmi_password")))
 
         user_id = param["user_id"]
         try:
@@ -295,7 +319,6 @@ class ZoomConnector(BaseConnector):
 
         action_result.update_summary(
             {
-                "pmi_password": ("Not Updated" if not (pmi_password) else pmi_password),
                 "waiting_room": ("Not Updated" if not is_waiting_room_updated else waiting_room),
                 "require_password_for_instant_meetings": ("Not Updated" if not is_req_password_inst_updated else req_password_inst),
                 "require_password_for_scheduling_new_meetings": ("Not Updated" if not is_req_password_sched_updated else req_password_sched),
@@ -340,7 +363,7 @@ class ZoomConnector(BaseConnector):
     def _handle_create_meeting(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._without_secret_parameters(param, "password")))
 
         user_id = param["user_id"]
         try:
@@ -395,13 +418,12 @@ class ZoomConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
-        action_result.add_data(res)
+        action_result.add_data(self._without_meeting_credentials(res))
 
         action_result.update_summary(
             {
                 "meeting_id": str(res["id"]),
                 "meeting_created": True,
-                "password": password if password else "Not Added",
                 "waiting_room": ("Not Added" if waiting_room == "None" else waiting_room),
                 "alternative_hosts": ("Not Added" if not alternative_hosts else alternative_hosts),
                 "continuous_meeting_chat": ("Not Added" if not continuous_meeting_chat else str(continuous_meeting_chat)),
@@ -416,7 +438,7 @@ class ZoomConnector(BaseConnector):
     def _handle_update_meeting(self, param):
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
 
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        action_result = self.add_action_result(ActionResult(self._without_secret_parameters(param, "password")))
 
         meeting_id = param["meeting_id"]
         try:
@@ -441,9 +463,7 @@ class ZoomConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
-        action_result.update_summary(
-            {"meeting_updated": True, "password": password, "waiting_room": ("Not Updated" if waiting_room == "None" else waiting_room)}
-        )
+        action_result.update_summary({"meeting_updated": True, "waiting_room": ("Not Updated" if waiting_room == "None" else waiting_room)})
 
         return action_result.set_status(phantom.APP_SUCCESS, f"Meeting {meeting_id} successfully updated")
 
@@ -523,7 +543,7 @@ class ZoomConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
-        action_result.add_data(response)
+        action_result.add_data(self._without_meeting_credentials(response))
         return action_result.set_status(phantom.APP_SUCCESS, f"Meeting information for id {meeting_id} successfully retrieved")
 
     def _get_token(self, action_result):


### PR DESCRIPTION
## Summary

This PR remediates five Zoom connector security findings tracked by PAPP-38043 under ESPM-5228:

- validates and URL-encodes user and meeting identifiers before using them in API paths (PSAAS-30568 / VULN-93293 / FS-997)
- preserves omitted password-policy settings instead of serializing them as values (PSAAS-31833 / VULN-94557 / FS-3079)
- removes meeting and PMI passwords from action parameters, summaries, and returned meeting data (PSAAS-31899 / VULN-94623 / FS-3145)
- removes meeting credentials and password-bearing query parameters from `get meeting` results (PSAAS-32398 / VULN-95121 / FS-3644)
- keeps OAuth token response bodies and headers out of connector debug data (PSAAS-32173 / VULN-94896 / FS-3419)

## Implementation notes

- For PSAAS-30568, this uses reject-and-encode validation for dynamic path segments. It intentionally does not require numeric meeting IDs because Zoom also accepts UUID meeting identifiers.
- The manifest retains parameter output-path declarations required by the static connector hook. Runtime action parameters are sanitized before they are attached to `ActionResult`, so password values are not stored or returned.
- Removing credential-bearing result fields is a breaking change and is recorded in the commit trailer and release notes.

## Validation

- `pre-commit run --all-files` (including connector Docker tests)
- `python3 -m py_compile zoom_connector.py`
- `python3 -m json.tool zoom.json`
- signed commit verification

Authored and opened by Codex.

## Tracking

- PAPP: PAPP-38043
- PSAAS: PSAAS-30568, PSAAS-31833, PSAAS-31899, PSAAS-32173, PSAAS-32398
- Written by Codex.